### PR TITLE
No longer specify a background when adding an action.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ on ui elements by simply dragging your finger.
 
 
 ##Requirements and dependencies
-`BubbleActions` works with api level 16 and higher. It also is dependent on appcompat-v7.
+`BubbleActions` works with api level 14 and higher. It also is dependent on appcompat-v7.
 
 
 ##Gradle
 ```groovy
-compile 'me.samthompson:bubble-actions:1.0.1'
+compile 'me.samthompson:bubble-actions:1.1.0'
 ```
 
 
@@ -25,29 +25,21 @@ compile 'me.samthompson:bubble-actions:1.0.1'
 `BubbleActions` are built using a [fluent interface](https://en.wikipedia.org/wiki/Fluent_interface) 
 (similar to SnackBar) and supports adding up to 5 actions. You can build `BubbleActions` like this:
 ```java
-BubbleActions.on(myView)                                                                              // Note 1
-        .addAction("Star", R.drawable.ic_star, R.drawable.popup_item, new BubbleAction.Callback() {   // Note 2
+BubbleActions.on(myView)
+        .addAction("Star", R.drawable.bubble_star, new BubbleAction.Callback() {
             @Override
-            public void doAction() {                                                                  // Note 3
+            public void doAction() {
                     Toast.makeText(v.getContext(), "Star pressed!", Toast.LENGTH_SHORT).show();
                 }
             })
         // ... add more actions ...
-        .show();                                                                                      // Note 4
+        .show();
 ```
-1. We start off by declaring that we want `BubbleActions` on `myView`. Behind the scenes, the `BubbleActions` class uses
- reflection to get an instance of `ViewRootImpl` which will be used to detect touch events. If it doesn't find one, 
- it throws an `IllegalStateException`.
-2. We add an action. Each action consists of a label, a foreground drawable/drawable resource id, a background 
-drawable/drawable resource id, and a callback. The foreground drawable is the icon that appears inside the bubble, 
-the background drawable controls the shape of the background and how it reacts to being selected, and the label
-determines what text is displayed above the bubble.
-3. When the user lifts their finger while over a bubble, the cooresponding callback is fired. 
-This always happens on the main thread.
-4. Show the `BubbleActions` by calling the `show()` method. Unlike SnackBar or AlertDialog, this method is not thread safe, so attempting
-to show `BubbleActions` from a separate thread may lead to unexpected results. You do not necessarily have to show the 
-`BubbleActions` immediately; the `BubbleActions` object can be stored for later use. The actions will remain visible as 
-long as the user's finger is pressed to the screen.
+Every action in BubbleActions has 3 parts:
+
+1. an action name that will be displayed above the bubble,
+2. a drawable for the bubble itself, and
+3. a callback that will be executed on the main thread when the user lifts their finger over that action.
 
 ####Basic example
 In the activity we set a long click listener to show the `BubbleActions`:
@@ -56,19 +48,19 @@ findViewById(R.id.my_view).setOnLongClickListener(new View.OnLongClickListener()
         @Override
         public boolean onLongClick(final View v) {
             BubbleActions.on(v)
-                    .addAction("Star", R.drawable.ic_star, R.drawable.popup_item, new BubbleActions.Callback() {
+                    .addAction("Star", R.drawable.bubble_star, new BubbleActions.Callback() {
                         @Override
                         public void doAction() {
                             Toast.makeText(v.getContext(), "Star pressed!", Toast.LENGTH_SHORT).show();
                         }
                     })
-                    .addAction("Share", R.drawable.ic_share, R.drawable.popup_item, new BubbleActions.Callback() {
+                    .addAction("Share", R.drawable.bubble_share, new BubbleActions.Callback() {
                         @Override
                         public void doAction() {
                             Toast.makeText(v.getContext(), "Share pressed!", Toast.LENGTH_SHORT).show();
                         }
                     })
-                    .addAction("Hide", R.drawable.ic_hide, R.drawable.popup_item, new BubbleActions.Callback() {
+                    .addAction("Hide", R.drawable.bubble_hide, new BubbleActions.Callback() {
                         @Override
                         public void doAction() {
                             Toast.makeText(v.getContext(), "Hide pressed!", Toast.LENGTH_SHORT).show();

--- a/bubbleactions-sample/src/main/java/me/samthompson/bubbleactions_sample/RecyclerViewActivity.java
+++ b/bubbleactions-sample/src/main/java/me/samthompson/bubbleactions_sample/RecyclerViewActivity.java
@@ -58,19 +58,19 @@ public class RecyclerViewActivity extends AppCompatActivity {
                 @Override
                 public boolean onLongClick(final View v) {
                     BubbleActions.on(v)
-                            .addAction("Star", R.drawable.ic_star, R.drawable.popup_item, new BubbleActions.Callback() {
+                            .addAction("Star", R.drawable.bubble_star, new BubbleActions.Callback() {
                                 @Override
                                 public void doAction() {
                                     Toast.makeText(v.getContext(), "Star pressed on item " + item + "!", Toast.LENGTH_SHORT).show();
                                 }
                             })
-                            .addAction("Share", R.drawable.ic_share, R.drawable.popup_item, new BubbleActions.Callback() {
+                            .addAction("Share", R.drawable.bubble_share, new BubbleActions.Callback() {
                                 @Override
                                 public void doAction() {
                                     Toast.makeText(v.getContext(), "Share pressed on item " + item + "!", Toast.LENGTH_SHORT).show();
                                 }
                             })
-                            .addAction("Hide", R.drawable.ic_hide, R.drawable.popup_item, new BubbleActions.Callback() {
+                            .addAction("Hide", R.drawable.bubble_hide, new BubbleActions.Callback() {
                                 @Override
                                 public void doAction() {
                                     Toast.makeText(v.getContext(), "Hide pressed on item " + item + "!", Toast.LENGTH_SHORT).show();

--- a/bubbleactions-sample/src/main/res/drawable/bubble_hide.xml
+++ b/bubbleactions-sample/src/main/res/drawable/bubble_hide.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+</selector>

--- a/bubbleactions-sample/src/main/res/drawable/bubble_hide.xml
+++ b/bubbleactions-sample/src/main/res/drawable/bubble_hide.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-
-</selector>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/popup_item" />
+    <item android:drawable="@drawable/ic_hide" />
+</layer-list>

--- a/bubbleactions-sample/src/main/res/drawable/bubble_share.xml
+++ b/bubbleactions-sample/src/main/res/drawable/bubble_share.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+</selector>

--- a/bubbleactions-sample/src/main/res/drawable/bubble_share.xml
+++ b/bubbleactions-sample/src/main/res/drawable/bubble_share.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-
-</selector>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/popup_item" />
+    <item android:drawable="@drawable/ic_share" />
+</layer-list>

--- a/bubbleactions-sample/src/main/res/drawable/bubble_star.xml
+++ b/bubbleactions-sample/src/main/res/drawable/bubble_star.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+</selector>

--- a/bubbleactions-sample/src/main/res/drawable/bubble_star.xml
+++ b/bubbleactions-sample/src/main/res/drawable/bubble_star.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-
-</selector>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/popup_item" />
+    <item android:drawable="@drawable/ic_star" />
+</layer-list>

--- a/bubbleactions/build.gradle
+++ b/bubbleactions/build.gradle
@@ -7,7 +7,7 @@ android {
     resourcePrefix "bubble_actions_"
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 14
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"

--- a/bubbleactions/build.gradle
+++ b/bubbleactions/build.gradle
@@ -32,7 +32,7 @@ publish {
     groupId = GROUP_NAME
     artifactId = 'bubble-actions'
     version = VERSION_NAME
-    description = 'An open source implementation of the long press actions as seen in the Pinterest app.'
+    description = 'An open source implementation of the long press actions in the Pinterest app.'
     website = SITE_URL
     bintrayUser = BINTRAY_USER
     bintrayKey = BINTRAY_KEY

--- a/bubbleactions/src/main/java/me/samthompson/bubbleactions/BubbleActionOverlay.java
+++ b/bubbleactions/src/main/java/me/samthompson/bubbleactions/BubbleActionOverlay.java
@@ -16,6 +16,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.OvershootInterpolator;
 import android.widget.FrameLayout;
+import android.widget.ImageView;
 
 import com.sam.bubbleactions.R;
 
@@ -68,7 +69,7 @@ class BubbleActionOverlay extends FrameLayout {
     private float stopActionDistanceFromCenter;
     private float bubbleDimension;
     private RectF contentClipRect;
-    private View bubbleActionIndicator;
+    private ImageView bubbleActionIndicator;
     private int numActions = 0;
     private boolean overlayActive = false;
     private ObjectAnimator backgroundAnimator;
@@ -80,7 +81,7 @@ class BubbleActionOverlay extends FrameLayout {
         dragData = new ClipData(TAG, new String[] {TAG}, new ClipData.Item(TAG));
 
         LayoutInflater inflater = LayoutInflater.from(context);
-        bubbleActionIndicator = inflater.inflate(R.layout.bubble_actions_indicator, this, false);
+        bubbleActionIndicator = (ImageView) inflater.inflate(R.layout.bubble_actions_indicator, this, false);
         bubbleActionIndicator.setAlpha(0f);
         addView(bubbleActionIndicator, -1);
 
@@ -125,9 +126,9 @@ class BubbleActionOverlay extends FrameLayout {
         }
 
         if (bubbleActions.indicator != null) {
-            bubbleActionIndicator.setBackground(bubbleActions.indicator);
+            bubbleActionIndicator.setImageDrawable(bubbleActions.indicator);
         } else {
-            bubbleActionIndicator.setBackgroundResource(R.drawable.bubble_actions_indicator);
+            bubbleActionIndicator.setImageResource(R.drawable.bubble_actions_indicator);
         }
 
         contentClipRect.set(0, 0, getWidth(), getHeight());
@@ -168,8 +169,7 @@ class BubbleActionOverlay extends FrameLayout {
             // Bind action specifics to BubbleView
             BubbleActions.Action action = bubbleActions.actions[actionIndex];
             bubbleView.textView.setText(action.actionName);
-            bubbleView.imageView.setImageDrawable(action.foregroundDrawable);
-            bubbleView.imageView.setBackground(action.backgroundDrawable);
+            bubbleView.imageView.setImageDrawable(action.bubble);
             bubbleView.callback = action.callback;
 
             // Calculate and set the locations of the BubbleView

--- a/bubbleactions/src/main/java/me/samthompson/bubbleactions/BubbleActions.java
+++ b/bubbleactions/src/main/java/me/samthompson/bubbleactions/BubbleActions.java
@@ -63,7 +63,7 @@ public class BubbleActions {
     }
 
     /**
-     * Open up BubbleActions on a view, using the specified drawable as the indicator.
+     * Open up BubbleActions on a view.
      *
      * @param view the view that the BubbleActions are contextually connected to. The
      *             view must have a root view.
@@ -125,46 +125,40 @@ public class BubbleActions {
      * circles.
      *
      * @param actionName The label displayed above the bubble action
-     * @param foregroundRes The content of the bubble action
-     * @param backgroundRes The background of the bubble action used to determine shadow
+     * @param drawableRes The content of the bubble action
      * @param callback A callback run on the main thread when the action is selected
      * @return the BubbleActions instance that called this method
      */
-    public BubbleActions addAction(CharSequence actionName, int foregroundRes, int backgroundRes, Callback callback) {
+    public BubbleActions addAction(CharSequence actionName, int drawableRes, Callback callback) {
         Resources resources = root.getResources();
         Resources.Theme theme = root.getContext().getTheme();
-        addAction(actionName, ResourcesCompat.getDrawable(resources, foregroundRes, theme), ResourcesCompat.getDrawable(resources, backgroundRes, theme), callback);
+        addAction(actionName, ResourcesCompat.getDrawable(resources, drawableRes, theme), callback);
         return this;
     }
 
     /**
-     * Add an action using drawables. See the description at {@link #addAction(CharSequence, int, int, BubbleActions.Callback)} for
+     * Add an action using drawables. See the description at {@link #addAction(CharSequence, int, BubbleActions.Callback)} for
      * details.
      *
      * @param actionName The label displayed above the bubble action
-     * @param foreground The content of the bubble action
-     * @param background The background of the bubble action used to determine shadow
+     * @param drawable The content of the bubble action
      * @param callback A callback run on the main thread when the action is selected
      * @return the BubbleActions instance that called this method
      */
-    public BubbleActions addAction(CharSequence actionName, Drawable foreground, Drawable background, Callback callback) {
+    public BubbleActions addAction(CharSequence actionName, Drawable drawable, Callback callback) {
         if (numActions >= actions.length) {
             throw new IllegalStateException(TAG + ": cannot add more than " + BubbleActionOverlay.MAX_ACTIONS + " actions.");
         }
 
-        if (foreground == null) {
-            throw new IllegalArgumentException(TAG + ": the foreground drawable cannot resolve to null.");
-        }
-
-        if (background == null) {
-            throw new IllegalArgumentException(TAG + ": the background drawable cannot resolve to null.");
+        if (drawable == null) {
+            throw new IllegalArgumentException(TAG + ": the drawable cannot resolve to null.");
         }
 
         if (callback == null) {
             throw new IllegalArgumentException(TAG + ": the callback must not be null.");
         }
 
-        actions[numActions] = new Action(actionName, foreground, background, callback);
+        actions[numActions] = new Action(actionName, drawable, callback);
         numActions++;
 
         return this;
@@ -237,19 +231,17 @@ public class BubbleActions {
     };
 
     /**
-     * An abstraction of the bubble action. Each action has a foreground and a background drawable,
+     * An abstraction of the bubble action. Each action has a name, a drawable for the bubble,
      * as well as a callback.
      */
     static class Action {
         CharSequence actionName;
-        Drawable foregroundDrawable;
-        Drawable backgroundDrawable;
+        Drawable bubble;
         Callback callback;
 
-        private Action(CharSequence actionName, Drawable foregroundDrawable, Drawable backgroundDrawable, Callback callback) {
+        private Action(CharSequence actionName, Drawable bubble, Callback callback) {
             this.actionName = actionName;
-            this.foregroundDrawable = foregroundDrawable;
-            this.backgroundDrawable = backgroundDrawable;
+            this.bubble = bubble;
             this.callback = callback;
         }
     }

--- a/bubbleactions/src/main/java/me/samthompson/bubbleactions/BubbleUtil.java
+++ b/bubbleactions/src/main/java/me/samthompson/bubbleactions/BubbleUtil.java
@@ -1,0 +1,7 @@
+package me.samthompson.bubbleactions;
+
+/**
+ * Created by sam on 11/24/15.
+ */
+public class BubbleUtil {
+}

--- a/bubbleactions/src/main/java/me/samthompson/bubbleactions/BubbleUtil.java
+++ b/bubbleactions/src/main/java/me/samthompson/bubbleactions/BubbleUtil.java
@@ -1,7 +1,43 @@
 package me.samthompson.bubbleactions;
 
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.LayerDrawable;
+import android.support.v4.content.res.ResourcesCompat;
+
 /**
- * Created by sam on 11/24/15.
+ * A collection of helper methods for use with BubbleActions.
  */
 public class BubbleUtil {
+
+    private BubbleUtil() {}
+
+    /**
+     * Create a drawable to be used as for a bubble. This is not necessarily the best way to create
+     * drawables for your bubbles, and you should probably use a layer-list or combine the icon and
+     * background in your favorite image editing program.
+     *
+     * @param context used to load the resource
+     * @param iconRes resource id of the icon drawable
+     * @param backgroundRes resource id for the background drawable
+     * @return a drawable where the icon appears over the background
+     */
+    public static Drawable makeBubbleDrawable(Context context, int iconRes, int backgroundRes) {
+        return makeBubbleDrawable(ResourcesCompat.getDrawable(context.getResources(), iconRes, context.getTheme()),
+                ResourcesCompat.getDrawable(context.getResources(), backgroundRes, context.getTheme()));
+    }
+
+    /**
+     * Create a drawable to be used as for a bubble. This is not necessarily the best way to create
+     * drawables for your bubbles, and you should probably use a layer-list or combine the icon and
+     * background in your favorite image editing program.
+     *
+     * @param icon drawable for the icon
+     * @param background drawable for the background
+     * @return a drawable where the icon appears over the background
+     */
+    public static Drawable makeBubbleDrawable(Drawable icon, Drawable background) {
+        return new LayerDrawable(new Drawable[]{icon, background});
+    }
+
 }

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
-code=2
+code=3
 major=1
-minor=0
-patch=1
+minor=1
+patch=0


### PR DESCRIPTION
LayerDrawable can handle the combining of an icon and a background for us, so there's no need to specify both.