### PR TITLE
Start drag event before animating

### DIFF
--- a/bubbleactions-sample/build.gradle
+++ b/bubbleactions-sample/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     compile 'com.android.support:recyclerview-v7:23.1.1'
     compile 'com.android.support:cardview-v7:23.1.1'
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile 'com.facebook.stetho:stetho:1.2.0'
 }
 buildscript {
     ext.kotlin_version = '1.0.0-beta-2423'

--- a/bubbleactions-sample/src/main/AndroidManifest.xml
+++ b/bubbleactions-sample/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="me.samthompson.bubbleactions_sample" >
 
     <application
+        android:name=".BubbleActionsApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/bubble_actions_app_name"

--- a/bubbleactions-sample/src/main/java/me/samthompson/bubbleactions_sample/BubbleActionsApplication.java
+++ b/bubbleactions-sample/src/main/java/me/samthompson/bubbleactions_sample/BubbleActionsApplication.java
@@ -1,0 +1,18 @@
+package me.samthompson.bubbleactions_sample;
+
+import android.app.Application;
+
+import com.facebook.stetho.Stetho;
+
+/**
+ * Created by sam on 12/9/15.
+ */
+public class BubbleActionsApplication extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        Stetho.initializeWithDefaults(this);
+    }
+
+}

--- a/bubbleactions/src/main/java/me/samthompson/bubbleactions/BubbleActions.java
+++ b/bubbleactions/src/main/java/me/samthompson/bubbleactions/BubbleActions.java
@@ -217,22 +217,7 @@ public final class BubbleActions {
             }
         });
 
-        overlay.getAnimateSetShow()
-                .setListener(new ViewPropertyAnimatorListenerAdapter() {
-                    @Override
-                    public void onAnimationStart(View view) {
-                        super.onAnimationStart(view);
-                        overlay.animateDimBackground();
-                    }
-
-                    @Override
-                    public void onAnimationEnd(View view) {
-                        super.onAnimationEnd(view);
-                        showing = true;
-                        overlay.startDrag();
-                    }
-                })
-                .start();
+        overlay.startDrag();
     }
 
     void removeOverlay() {
@@ -247,7 +232,29 @@ public final class BubbleActions {
             final int action = event.getAction();
 
             switch (action) {
-                case DragEvent.ACTION_DROP:
+                case DragEvent.ACTION_DRAG_STARTED:
+                    if (DragUtils.isDragForMe(event.getClipDescription().getLabel())) {
+                        overlay.getAnimateSetShow()
+                                .setListener(new ViewPropertyAnimatorListenerAdapter() {
+                                    @Override
+                                    public void onAnimationStart(View view) {
+                                        super.onAnimationStart(view);
+                                        overlay.animateDimBackground();
+                                    }
+
+                                    @Override
+                                    public void onAnimationEnd(View view) {
+                                        super.onAnimationEnd(view);
+                                        showing = true;
+                                    }
+                                })
+                                .start();
+                        return true;
+                    } else {
+                        return false;
+                    }
+
+                case DragEvent.ACTION_DRAG_ENDED:
                     overlay.getAnimateSetHide()
                             .setListener(new ViewPropertyAnimatorListenerAdapter() {
                                 @Override

--- a/bubbleactions/src/main/java/me/samthompson/bubbleactions/BubbleView.java
+++ b/bubbleactions/src/main/java/me/samthompson/bubbleactions/BubbleView.java
@@ -109,7 +109,7 @@ class BubbleView extends LinearLayout {
                     callback.doAction();
 
                     // we return false here so we are notified in the BubbleActionOverlay
-                    return false;
+                    return true;
             }
             return false;
         }


### PR DESCRIPTION
Resolves #9 

The bug was occurring because we weren't receiving a callback in the BubbleActionOverlay's OnDragListener telling us that the drag operation had concluded.

In the process of looking at this issue, I also added Stetho to check that only one BubbleActionOverlay was attached to the root view. Until the project has test cases to check for this, Stetho will be useful.